### PR TITLE
fix(ricons): wrong class name for Icon component

### DIFF
--- a/packages/ricons-utils/src/Icon.tsx
+++ b/packages/ricons-utils/src/Icon.tsx
@@ -24,7 +24,7 @@ export function Icon ({ size, color, tag = 'span', children }: IconProps) {
   }, [])
   return (
     <MergedTag 
-      className="xicons"
+      className="xicon"
       style={{
         color: mergedColor,
         fontSize: mergedSize


### PR DESCRIPTION
The Icon component in `@ricons/utils` has provided a wrong class name: `.xicons`, and the correct one should be `.xicon`.